### PR TITLE
#162163000:implement password reset by email

### DIFF
--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,15 +1,20 @@
-from django.conf.urls import url
+from django.urls import path
 from rest_framework_swagger.views import get_swagger_view
 
 schema_view = get_swagger_view(title='Authors Heaven')
 
 from .views import (
-    LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView
+    LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView,
+    ResetPasswordView, ResetPasswordView, ChangePasswordView
 )
 
 urlpatterns = [
-    url(r'^user/?$', UserRetrieveUpdateAPIView.as_view(), name='retrieve_user'),
-    url(r'^users/?$', RegistrationAPIView.as_view(), name='authentication'),
-    url(r'^users/login/?$', LoginAPIView.as_view(), name='login'),
-    url(r'^swagger/', schema_view),
+    path('user/', UserRetrieveUpdateAPIView.as_view(), name='retrieve_user'),
+    path('users/', RegistrationAPIView.as_view(), name='authentication'),
+    path('users/login/', LoginAPIView.as_view(), name='login'),
+    path('swagger/', schema_view),
+    path('password-reset/', ResetPasswordView.as_view(), name='password-reset'),
+    path('password-reset/<str:token>/',
+         ResetPasswordView.as_view(), name='password-reset'),
+    path('password/reset/done/', ChangePasswordView.as_view(), name='password-reset'),
 ]

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -1,14 +1,15 @@
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, UpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.generics import GenericAPIView
+from .models import User
 
 from .renderers import UserJSONRenderer
 from .serializers import (
-    LoginSerializer, RegistrationSerializer, UserSerializer
+    LoginSerializer, RegistrationSerializer, UserSerializer,
+    ResetPasswordSerializer
 )
-
 
 class RegistrationAPIView(GenericAPIView):
     # Allow any user (authenticated or not) to hit this endpoint.
@@ -62,9 +63,6 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
     def update(self, request, *args, **kwargs):
         serializer_data = request.data.get('user', {})
-
-        # Here is that serialize, validate, save pattern we talked about
-        # before.
         serializer = self.serializer_class(
             request.user, data=serializer_data, partial=True
         )
@@ -73,3 +71,51 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+
+class ResetPasswordView(RetrieveUpdateAPIView):
+    permission_classes = (AllowAny,)
+    renderer_classes = (UserJSONRenderer,)
+    serializer_class = ResetPasswordSerializer
+    def post(self, request):
+        """
+        This post method handle functionality of 
+        sending user email
+        It queries user form databse and show user customised message
+        upon succesfull email sending
+        """
+        
+        user = request.data.get('user', {})
+        serializer = self.serializer_class(data=user)
+        serializer.is_valid(raise_exception=True)
+        data = {
+            "Message": "A link has been sent to your email"
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    def retrieve(self, request, token, *args, **kwargs):
+        """
+        This allows one to retrive the token from the end point
+        after it has sent from the user mail
+        """
+        msg = {'token': token}
+        return Response(msg, status=status.HTTP_200_OK)
+
+
+class ChangePasswordView(UpdateAPIView):
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (UserJSONRenderer,)
+    serializer_class = UserSerializer
+    def update(self, request, *args, **kwargs):
+        serializer_data = request.data.get('user', {})
+        """
+        Here is that serialize, validate, save pattern we talked about
+        before.
+        It gets user data and passes that throught the token of the user
+        """
+        serializer = self.serializer_class(
+            request.user, data=serializer_data, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        msg = {'Message': 'Your password has been updated succesfully'}
+        return Response(msg, status=status.HTTP_200_OK) 

--- a/authors/apps/tests/test_reset_password.py
+++ b/authors/apps/tests/test_reset_password.py
@@ -1,0 +1,76 @@
+from authors.apps.authentication.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from .test_validation import AccountTests
+
+from . import (new_user, user_login)
+
+
+
+class PassordResetTests(APITestCase):
+    """handles user reseting passwordtests"""
+    account_tests = AccountTests()
+
+    def test_reset_user_password(self):
+        """
+        test validates whether email exits the it sends password
+        reset lint to that email
+        """
+        self.client.post("/api/users/", new_user, format="json")
+        self.client.post("/api/users/login/", user_login, format="json")
+        response = self.client.post(
+            "/api/password-reset/",
+            data={"user": {
+                "email": " jak@jake.jake"
+            }},
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(response.data['Message'],
+                      "A link has been sent to your email")
+
+    def test_confirm_reset_user_password_status_code(self):
+        """
+        test ckecks whether token is in the link the user has clicked
+        on his mail
+        """
+        response = self.client.get(
+            "/api/password-reset/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+            "eyJpZCI6NCwiZW1haWwiOiJnYWJyaWVsQGdtYWlsLmNvbSIsImV4cCI6MTU0NDQ1NjIzNH0."
+            "O4x6zL17kRthBPFP1MrYES3TjY34j4rlS7u-Gm4pwSc"
+            "/",
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert "token" in response.data
+
+    def test_confirm_reset_without_token(self):
+        """
+        Tests checks for return of error when user doesnt have token
+        """
+        response = self.client.put("/api/password/reset/done/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn(
+            response.data['detail'],
+            "ErrorDetail(string='Authentication credentials were not provided.',"
+            "code='not_authenticated')")
+
+    def test_confirm_reset(self):
+        """"This method tests successful reseting of a user password"""
+        
+        self.password_update = {"user": {"password": "Newpaswd1"}}
+        res = self.client.post("/api/users/", new_user, format="json")
+        token = res.data['token']
+        response = self.client.get("/api/password-reset/{}/".format(token))
+        token = response.data['token']
+        self.add_credentials(response.data['token'])
+        response = self.client.put(
+            "/api/password/reset/done/",
+            data=self.password_update,
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(response.data['Message'],
+                      "Your password has been updated succesfully")
+
+    def add_credentials(self, response):
+        """adds authentication credentials in the request header"""
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + response)

--- a/authors/apps/tests/test_validation.py
+++ b/authors/apps/tests/test_validation.py
@@ -115,7 +115,7 @@ class AccountTests(APITestCase):
                       'user with this email already exists.')
 
     def test_duplicate_username(self):
-        "user with same username provided exists"""
+        """user with same username provided exists"""
         self.register_user(new_user)
         response = self.register_user(dup_username)
         self.assertIn(response.data["errors"]["username"][0],


### PR DESCRIPTION
#### What does this PR do?
Sends an email to the user with the password reset link upon user request
#### Description of the tasks to be completed?
Have the following endpoints working
- `api/password-reset/`. This sends email to the user.
- `api/password-reset/<str:token>/`. retrieves the token from the link
- `api/password/reset/done/`. Used to update
#### How should this be manually tested?
- Pull the branch to your remote workspace
- Run the server using `python manage.py runserver`
- The user puts in his email into the email field by appending `/api/password-reset/`
- On Postman add this to the body.
```
{
    "user": {
		  "email": "gabriel.okello@andela.com"
		}
}
```
- System Sends an email to the user with the password reset link upon user request
- The user receives an email with a link like `http://127.0.0.1:8000/api/password-reset/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NSwiZW1haWwiOiJnYWJyaWVsLm9rZWxsb0BhbmRlbGEuY29tIiwiZXhwIjoxNTQ0NDUzMDA5fQ.vwwWpYMDRaFygFUG-5qiL8xnx4Gsd0ti3CsNIc9NVdg/`
- Clicks / copy the link on this email post it on Postman which returns user token
- Get the token and pass it on the header on Postman input method and use the following on the body'
```
{
  "user":{
    "password": "newpassword"
  }
}
```
#### What are the relevant pivotal tracker stories?
#162163000