### PR TITLE
#162163010 Users should be able to see a list of all authors

### DIFF
--- a/authors/apps/profiles/exceptions.py
+++ b/authors/apps/profiles/exceptions.py
@@ -2,7 +2,7 @@ from rest_framework.exceptions import APIException
 
 
 class ProfileDoesNotExist(APIException):
-    status_code = 400
+    status_code = 404
     default_detail = """Profile does not exist. Cross-check the provided username."""
 
 

--- a/authors/apps/profiles/renderers.py
+++ b/authors/apps/profiles/renderers.py
@@ -11,12 +11,17 @@ class ProfileJSONRenderer(JSONRenderer):
         # or something similar), `data` will contain an `errors` key. We want
         # the default JSONRenderer to handle rendering errors, so we need to
         # check for this case.
+        response = json.dumps({'profile': data})
+
+        if isinstance(data, list):
+            return json.dumps({'profiles': data})
+
         errors = data.get('errors', None)
 
         if errors is not None:
             # As mentioned about, we will let the default JSONRenderer handle
             # rendering errors.
-            return super(ProfileJSONRenderer, self).render(data)
+            response = super(ProfileJSONRenderer, self).render(data)
 
-        # Finally, we can render our data under the "user" namespace.
-        return json.dumps({'profile': data})
+        # Finally, we can render our data under the "profile" namespace.
+        return response

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ProfileRetrieveAPIView, FollowAuthorAPIView
+from .views import ProfileRetrieveAPIView, FollowAuthorAPIView, ListAuthorsAPIView
 
 urlpatterns = [
     path(
@@ -10,4 +10,5 @@ urlpatterns = [
         'profiles/<username>/follow',
         FollowAuthorAPIView.as_view(),
         name="user_follow"),
+    path('profiles/', ListAuthorsAPIView.as_view(), name="users_profiles"),
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -70,3 +70,13 @@ class FollowAuthorAPIView(generics.GenericAPIView):
             followee, context={'request': request})
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ListAuthorsAPIView(generics.ListAPIView):
+    """
+    Implements listing of all users' profiles
+    """
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer
+    renderer_classes = (ProfileJSONRenderer, )
+    permission_classes = (permissions.IsAuthenticated, )

--- a/authors/apps/tests/test_profile.py
+++ b/authors/apps/tests/test_profile.py
@@ -16,20 +16,27 @@ class ProfileTestCase(BaseTestCase):
         response = self.client.get(url)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
 
+    def test_list_all_users_profiles(self):
+        "Tests listing all profiles."
+
+        self.authorize_user()
+        url = reverse('users_profiles')
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+
     def test_get_user_profile_who_does_not_exist(self):
         "Tests getting profile of a user who is not registered."
 
         response = self.client.get(
             reverse('get_profile', kwargs={'username': 'john'}))
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_user_profile(self):
         "Tests updating of a user profile."
 
         url = reverse('retrieve_user')
-        res = self.register_user(new_user)
-        self.add_credentials(res.data['token'])
+        self.authorize_user()
 
         response = self.client.put(
             url,
@@ -50,8 +57,7 @@ class UserFollowingTestCase(BaseTestCase):
         "Tests if users a can follow each other."
 
         self.register_user(new_user_2)
-        res = self.register_user(new_user)
-        self.add_credentials(res.data['token'])
+        self.authorize_user()
 
         response = self.client.post(
             reverse('user_follow', kwargs={'username': 'John'}))
@@ -61,8 +67,7 @@ class UserFollowingTestCase(BaseTestCase):
     def test_a_user_following_themselves(self):
         "Tests if a user can follow themselves."
 
-        res = self.register_user(new_user)
-        self.add_credentials(res.data['token'])
+        self.authorize_user()
 
         response = self.client.post(
             reverse('user_follow', kwargs={'username': 'Jac'}))
@@ -74,8 +79,7 @@ class UserFollowingTestCase(BaseTestCase):
         "Tests unfollowing of users."
 
         self.register_user(new_user_2)
-        res = self.register_user(new_user)
-        self.add_credentials(res.data['token'])
+        self.authorize_user()
         self.client.post(reverse('user_follow', kwargs={'username': 'John'}))
 
         response = self.client.delete(
@@ -86,8 +90,7 @@ class UserFollowingTestCase(BaseTestCase):
     def test_follow_or_unfollow_user_who_does_not_exist(self):
         "Tests following of a user who does not exist."
 
-        res = self.register_user(new_user)
-        self.add_credentials(res.data['token'])
+        self.authorize_user()
 
         response = self.client.post(
             reverse('user_follow', kwargs={'username': 'Joan'}))


### PR DESCRIPTION
#### What does this PR do?
- Enable user to see a list of profiles for all the users
- Write test for  list-users endpoint

#### Description of the tasks to be completed?
- Update `views` file in `Profiles` app
- Update `ProfileJSONRenderer` class in `Profiles` app renderers file

#### How should this be manually tested?
- Pull this branch to your local workspace
- Run `git checkout ft-user-following-162163007` command in the terminal to switch to this feature's branch
- Create a postgres database called `ahdb` and make migrations by running:
        - `python manage.py makemigrations`
        - `python manage.py migrate` 
- Run the server using `python manage.py runserver`

##### *Don't forget: Append the endpoints to the server URL*

- Register any number of new users by making `POST` requests with the user's JSON data to `api/users/` endpoint using Swagger documentation on `/docs` or POSTMAN.
```
Data format
{
  "user": {
        "email": "lule@dev.com",
        "username": "lule",
        "password": "luleadmin",
  }
}
```
- Copy and paste the token of any user in the headers (if using POSTMAN).
```
Key = "Authorization"
value = "Token<space><token.here>"
```
- Make a `GET` request to `api/profiles/` with the user whose token you have copied and you should see the profiles of all users.
```
{
    "profiles": [
        {
            "username": "dan",
            "email": "dan@gmail.com",
            "bio": "",
            "image": null,
            "following": false
        },
        {
            "username": "lule",
            "email": "lule@gmail.com",
            "bio": "",
            "image": null,
            "following": false
        }
    ]
}
```
#### Relevant pivotal tracker stories
#162163010