### PR TITLE
#162163016 Users should be able to bookmark articles for reading later

### DIFF
--- a/authors/apps/article/urls.py
+++ b/authors/apps/article/urls.py
@@ -5,13 +5,15 @@ from django.conf.urls import url
 from django.urls import path
 
 from .views import (ArticleAPIView, ArticleListView, ArticleRetrieveAPIView,
-                    RatingsView, FavouritesAPIView)
+                    RatingsView, FavouritesAPIView, BookmarksAPIView)
 
 urlpatterns = [
     # article urls
     path("articles/", ArticleAPIView.as_view(), name="articles"),
-    path("articles/<slug>/", ArticleRetrieveAPIView.as_view(),
-         name="get_update_destroy_article"),
+    path(
+        "articles/<slug>/",
+        ArticleRetrieveAPIView.as_view(),
+        name="get_update_destroy_article"),
     # rating urls
     path("<slug>/rate/", RatingsView.as_view(), name="rating"),
     path(
@@ -20,8 +22,14 @@ urlpatterns = [
         name="get_update_destroy_article"),
     url(r'^articles?$', ArticleListView.as_view(), name="filter_articles"),
     # favouring article
-    path('<slug>/favourite/',
-         FavouritesAPIView.as_view(), name="favourite"),
-    path('<slug>/favourite/',
-         FavouritesAPIView.as_view(), name="undo_favourite"),
+    path('<slug>/favourite/', FavouritesAPIView.as_view(), name="favourite"),
+    path(
+        '<slug>/favourite/',
+        FavouritesAPIView.as_view(),
+        name="undo_favourite"),
+    path(
+        '<slug>/bookmark/',
+        BookmarksAPIView.as_view(),
+        name="bookmark_article"),
+    path('bookmarks/', BookmarksAPIView.as_view(), name="bookmarked_articles")
 ]

--- a/authors/apps/article/utils.py
+++ b/authors/apps/article/utils.py
@@ -5,6 +5,8 @@ import math
 from datetime import datetime
 
 from django.template.defaultfilters import slugify
+from rest_framework import status
+from rest_framework.response import Response
 
 
 def generate_slug(article, self):
@@ -20,9 +22,9 @@ def generate_slug(article, self):
     new_slug = slugify(self.title)
 
     if article.objects.filter(slug=new_slug).count() > 0:
-        size = math.floor(len(self.description.split())/2)
-        new_slug = slugify(
-            new_slug + " " + " ".join(self.description.split()[:size]))
+        size = math.floor(len(self.description.split()) / 2)
+        new_slug = slugify(new_slug + " " +
+                           " ".join(self.description.split()[:size]))
 
     if article.objects.filter(slug=new_slug).count() > 0:
         new_slug = slugify(new_slug + "-" + generate_unique_number())
@@ -36,3 +38,22 @@ def generate_unique_number():
     :return:
     """
     return datetime.now().strftime("%Y%m%d%H%M%S%f")
+
+
+def bookmark_validator(article, request):
+    """
+    validator method for bookmarking article
+    """
+    user = request.user
+    author = article.author
+    bookmarked = article.is_bookmarked(user)
+    if author == user:
+        return Response({
+            "message": "You can't bookmark your own article",
+        },
+                        status=status.HTTP_400_BAD_REQUEST)
+    if bookmarked:
+        return Response({
+            "message": "Article already bookmarked by you",
+        },
+                        status=status.HTTP_400_BAD_REQUEST)

--- a/authors/apps/tests/base.py
+++ b/authors/apps/tests/base.py
@@ -157,3 +157,22 @@ class BaseTestCase(APITestCase):
 
     def remove_all_articles(self):
         Article.objects.all().delete()
+        
+    def data_for_bookmarks(self):
+        self.post_articles_for_search()
+        self.authorize_user2()
+        article_data = self.client.get(ARTICLE_URL, format='json')
+        data = article_data.json().get("articles")
+        slug = data["results"][0]["slug"]
+        return slug
+
+    def url_for_bookmarks(self):
+        slug = self.data_for_bookmarks()
+        url = reverse('bookmark_article', kwargs={'slug': slug})
+        return url
+
+    def url_for_invalid_slug(self):
+        slug = self.data_for_bookmarks()
+        slug = slug + 'hello'
+        url = reverse('bookmark_article', kwargs={'slug': slug})
+        return url

--- a/authors/apps/tests/test_bookmark.py
+++ b/authors/apps/tests/test_bookmark.py
@@ -1,0 +1,76 @@
+from django.urls import reverse
+from authors.apps.tests.base import BaseTestCase
+from . import ARTICLE_URL
+
+
+class BookmarksTestCase(BaseTestCase):
+    """tests for bookmarks"""
+
+    def test_bookmark_article(self):
+        """test if article is bookmarked"""
+        url = self.url_for_bookmarks()
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201)
+        self.assertIn(response.data['message'], 'Article bookmarked')
+
+    def test_get_bookmarked_articles(self):
+        """fetch bookmarked articles test"""
+        url = self.url_for_bookmarks()
+        self.client.post(url)
+        url2 = reverse('bookmarked_articles')
+        response = self.client.get(url2)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.json(), list)
+
+    def test_unbookmark_article(self):
+        """assert article unbookmarked"""
+        url = self.url_for_bookmarks()
+        self.client.post(url)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(response.data['message'], 'Article unbookmarked')
+
+    def test_already_bookmarked(self):
+        """assert article already bookmarked"""
+        url = self.url_for_bookmarks()
+        self.client.post(url)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(response.data['message'],
+                      'Article already bookmarked by you')
+
+    def test_no_articles_bookmarked(self):
+        """test no articles bookmarked"""
+        self.post_articles_for_search()
+        self.authorize_user2()
+        url = reverse('bookmarked_articles')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(response.data['message'], 'No articles bookmarked yet')
+
+    def test_article_not_found(self):
+        """check specific article not found for bookmarking"""
+        url = self.url_for_invalid_slug()
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(response.data['detail'], 'Article not found')
+
+    def test_unbookmark_article_not_bookmarked(self):
+        """assert article not bookmarked can't be unbookmarked"""
+        url = self.url_for_invalid_slug()
+        self.client.post(url)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(response.data['detail'], 'Article not in bookmark list')
+
+    def test_bookmark_own_article(self):
+        """check if author can't bookmark their article"""
+        self.post_articles_for_search()
+        article_data = self.client.get(ARTICLE_URL, format='json')
+        data = article_data.json().get("articles")
+        slug = data["results"][0]["slug"]
+        url = reverse('bookmark_article', kwargs={'slug': slug})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(response.data['message'],
+                      "You can't bookmark your own article")


### PR DESCRIPTION
**What does this PR do?**
Implement bookmark feature for users to bookmark articles to read later.

**Description of tasks to be completed?**
- Add bookmarks ManytoMany field descriptor in Article models
- Create views for bookmarks.
- Write tests for bookmarks feature.

**How can this be manually tested?**
- On your local machine, checkout the develop (`git checkout develop`) branch and pull the changes.
- Then checkout this  feature branch using `git checkout ft-bookmark-articles-162163016`
- Open your editor and go to the project workspace.
- Activate the virtual environment and install the dependencies.
- Create a Postgres database called `ahdb` and make migrations by running:
        * `python manage.py makemigrations`
        * `python manage.py migrate` 
- Run the server using python manage.py runserver
- Using swagger docs on (`http://127.0.0.1:8000/docs/`), create different articles using different users with the following format. Use the `POST /articles/` endpoint 
```
{
  "article": {
    "title": "OOP",
    "description": "About the use of classes and objects",
    "body": "Do you know about Python methods?.Welcome, home   as we dive deep.",
    "tags": ["python", "programming", "technology"]
  }
}
```
- Bookmark any of the articles of another user (ie. author can't bookmark his own article). Use a slug for the specific article to be bookmarked using the `POST /api/{slug}/bookmark/` endpoint.
- Fetch all articles you bookmarked using the `GET /api/bookmarks/` endpoint.
- Unbookmark an article using the `DELETE /api/{slug}/bookmark/` while providing the slug for the article.

**What are the related pivotal tracker stories?**
- #162163016